### PR TITLE
66 feature deprecated ci pipeline finished ci pipeline status ci pipeline files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ echo "go mod vendor"
       before `wd_urfave_cli_v2.UrfaveCliBindInfo()`
 - [x] `wd_info.WoodpeckerInfo` is plugin most use env args
   from [woodpecker-ci/woodpecker](https://github.com/woodpecker-ci/woodpecker)
+    - Deprecated `CI_PIPELINE_FINISHED` and `CI_PIPELINE_STARTED` for support woodpecker server 3.+ (v1.22+)  
 - [x] `wd_info.CiSystemVersionMinimumSupport` and `wd_info.CiSystemVersionConstraint` can check plugin support ci system
   version
 - [x] `wd_urfave_cli_v2.WoodpeckerUrfaveCliFlags()` bind cli

--- a/wd_flag/flag_current_pipeline.go
+++ b/wd_flag/flag_current_pipeline.go
@@ -1,8 +1,8 @@
 package wd_flag
 
 const (
-	// NameCliCurrentPipelineFiles
-	//  Provides the current pipeline files, like [".woodpecker/.build.yml"]
+	// Deprecated: remove at woodpecker server 3.0.0
+	// Provides the current pipeline files, like [".woodpecker/.build.yml"]
 	NameCliCurrentPipelineFiles = "current_pipeline.files"
 
 	// EnvKeyCurrentPipelineFiles
@@ -81,11 +81,11 @@ const (
 	//  Provides the current pipeline started UNIX timestamp
 	EnvKeyCurrentPipelineStarted = "CI_PIPELINE_STARTED"
 
-	// NameCliCurrentPipelineFinished
+	// Deprecated: remove at woodpecker server 3.0.0
 	//  Provides the current pipeline finished UNIX timestamp
 	NameCliCurrentPipelineFinished = "current_pipeline.finished"
 
-	// EnvKeyCurrentPipelineFinished
+	// Deprecated: remove at woodpecker server 3.0.0
 	//  Provides the current pipeline finished UNIX timestamp
 	EnvKeyCurrentPipelineFinished = "CI_PIPELINE_FINISHED"
 )

--- a/wd_flag/time_tools.go
+++ b/wd_flag/time_tools.go
@@ -41,6 +41,14 @@ func FormatTimeUTC(timestamp uint64, format string) string {
 	return time.Unix(int64(timestamp), 0).UTC().Format(format)
 }
 
+func GetNowTimestampSecond() int64 {
+	return time.Now().Unix()
+}
+
+func GetNowTimestampMicroseconds() int64 {
+	return time.Now().UnixMicro()
+}
+
 // DistanceBetweenTimestampSecondHuman
 // convert DistanceBetweenTimestampSecond to human-readable
 //

--- a/wd_info/wd_info.go
+++ b/wd_info/wd_info.go
@@ -237,10 +237,10 @@ type (
 	// CurrentPipelineInfo
 	//  woodpecker current pipeline info.
 	CurrentPipelineInfo struct {
-		// CiPipelineFiles
+		// Deprecated: remove at woodpecker 3.0.0.
 		//  Provides the current pipeline files, like [".woodpecker/.build.yml"]
 		//  by env: CI_PIPELINE_FILES
-		CiPipelineFiles string `mock_env_key:"CI_PIPELINE_FILES"`
+		CiPipelineFiles string
 
 		// CiPipelineNumber
 		//  Provides the current pipeline number
@@ -275,6 +275,7 @@ type (
 		// CiPipelineStatus
 		//  Provides the current pipeline status
 		//  by env: CI_PIPELINE_STATUS
+		// Variables that do not clearly describe the state should be change in woodpecker 3.0.0 version
 		CiPipelineStatus string `mock_env_key:"CI_PIPELINE_STATUS"`
 
 		// CiPipelineCreated
@@ -297,19 +298,19 @@ type (
 		//  by env: CI_PIPELINE_STARTED
 		CiPipelineStartedT string
 
-		// CiPipelineFinished
+		// Deprecated: the pipeline can't know when it was finished while it's running, the state should be removed in woodpecker 3.0.0 version
 		//  Provides the current pipeline finished
 		//  by env: CI_PIPELINE_FINISHED
-		CiPipelineFinished uint64 `mock_env_key:"CI_PIPELINE_FINISHED"`
+		CiPipelineFinished uint64
 
-		// CiPipelineFinishedT
+		// Deprecated: remove at woodpecker server 3.0.0
 		// Provides the current pipeline finished, unix timestamp format by wd_flag.TimeFormatDefault
 		//  by env: CI_PIPELINE_FINISHED
 		CiPipelineFinishedT string
 
 		// CiPipelineDurationHuman
 		//  Provides the total pipeline time in seconds.
-		//  This value is calculated by subtracting the pipeline created timestamp from the build finished timestamp.
+		//  This value is calculated by subtracting the pipeline created timestamp from now timestamp.
 		CiPipelineDurationHuman string
 	}
 

--- a/wd_mock/wd_info_mock.go
+++ b/wd_mock/wd_info_mock.go
@@ -55,7 +55,10 @@ func NewWoodpeckerInfo(opts ...WoodpeckerInfoOption) (opt *wd_info.WoodpeckerInf
 func changByDroneEnv(info *wd_info.WoodpeckerInfo) {
 	if info.CurrentInfo.CurrentPipelineInfo.CiPipelineStatus == "" {
 		relateCIPipelineStatus := env_kit.FetchOsEnvStr(wd_flag.RelatedEnvDroneCIPipelineStatus, "")
-		info.CurrentInfo.CurrentPipelineInfo.CiPipelineStatus = relateCIPipelineStatus
+		// https://github.com/woodpecker-ci/woodpecker/pull/4193
+		if relateCIPipelineStatus != "" {
+			info.CurrentInfo.CurrentPipelineInfo.CiPipelineStatus = relateCIPipelineStatus
+		}
 	}
 }
 

--- a/wd_mock/wd_mock_current_pipeline_info.go
+++ b/wd_mock/wd_mock_current_pipeline_info.go
@@ -11,7 +11,6 @@ type CurrentPipelineInfoOption func(*wd_info.CurrentPipelineInfo)
 
 func setDefaultCurrentPipelineInfo() *wd_info.CurrentPipelineInfo {
 	return &wd_info.CurrentPipelineInfo{
-		CiPipelineFiles:         `[".woodpecker/.build.yml"]`,
 		CiPipelineNumber:        "10",
 		CiPipelineParent:        "0",
 		CiPipelineEvent:         "push",
@@ -23,8 +22,6 @@ func setDefaultCurrentPipelineInfo() *wd_info.CurrentPipelineInfo {
 		CiPipelineCreatedT:      wd_flag.FormatTimeUTCBySetting(1705658141),
 		CiPipelineStarted:       1705658156,
 		CiPipelineStartedT:      wd_flag.FormatTimeUTCBySetting(1705658156),
-		CiPipelineFinished:      1705658166,
-		CiPipelineFinishedT:     wd_flag.FormatTimeUTCBySetting(1705658166),
 		CiPipelineDurationHuman: wd_flag.DistanceBetweenTimestampSecondHuman(1705658141, 1705658166),
 	}
 }
@@ -38,9 +35,10 @@ func NewCurrentPipelineInfo(opts ...CurrentPipelineInfoOption) (opt *wd_info.Cur
 	return
 }
 
+// Deprecated: remove at woodpecker server v3.0.0
 func WithCiPipelineFiles(files string) CurrentPipelineInfoOption {
 	return func(o *wd_info.CurrentPipelineInfo) {
-		o.CiPipelineFiles = files
+		//o.CiPipelineFiles = files
 	}
 }
 
@@ -90,7 +88,7 @@ func WithCiPipelineCreated(created uint64) CurrentPipelineInfoOption {
 	return func(o *wd_info.CurrentPipelineInfo) {
 		o.CiPipelineCreated = created
 		o.CiPipelineCreatedT = wd_flag.FormatTimeUTCBySetting(created)
-		o.CiPipelineDurationHuman = wd_flag.DistanceBetweenTimestampSecondHuman(int64(o.CiPipelineCreated), int64(o.CiPipelineFinished))
+		o.CiPipelineDurationHuman = wd_flag.DistanceBetweenTimestampSecondHuman(int64(o.CiPipelineCreated), wd_flag.GetNowTimestampSecond())
 	}
 }
 
@@ -101,11 +99,12 @@ func WithCiPipelineStarted(started uint64) CurrentPipelineInfoOption {
 	}
 }
 
+// Deprecated: remove at woodpecker server v3.0.0
 func WithCiPipelineFinished(finished uint64) CurrentPipelineInfoOption {
 	return func(o *wd_info.CurrentPipelineInfo) {
-		o.CiPipelineFinished = finished
-		o.CiPipelineFinishedT = wd_flag.FormatTimeUTCBySetting(finished)
-		o.CiPipelineDurationHuman = wd_flag.DistanceBetweenTimestampSecondHuman(int64(o.CiPipelineStarted), int64(o.CiPipelineFinished))
+		//o.CiPipelineFinished = finished
+		//o.CiPipelineFinishedT = wd_flag.FormatTimeUTCBySetting(finished)
+		//o.CiPipelineDurationHuman = wd_flag.DistanceBetweenTimestampSecondHuman(int64(o.CiPipelineStarted), int64(o.CiPipelineFinished))
 	}
 }
 

--- a/wd_mock_test/testdata/TestFastMock/fastPullRequest.golden
+++ b/wd_mock_test/testdata/TestFastMock/fastPullRequest.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "pull_request",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestFastMock/fastTag.golden
+++ b/wd_mock_test/testdata/TestFastMock/fastTag.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "tag",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestFastMock/statusFailure.golden
+++ b/wd_mock_test/testdata/TestFastMock/statusFailure.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestFastMock/statusSuccess.golden
+++ b/wd_mock_test/testdata/TestFastMock/statusSuccess.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestNewCurrentPipelineInfo/one.golden
+++ b/wd_mock_test/testdata/TestNewCurrentPipelineInfo/one.golden
@@ -13,5 +13,5 @@
   "CiPipelineStartedT": "2024-01-19-04-22-36",
   "CiPipelineFinished": 0,
   "CiPipelineFinishedT": "",
-  "CiPipelineDurationHuman": "377d 22h 14m 30s"
+  "CiPipelineDurationHuman": "5s"
 }

--- a/wd_mock_test/testdata/TestNewCurrentPipelineInfo/one.golden
+++ b/wd_mock_test/testdata/TestNewCurrentPipelineInfo/one.golden
@@ -1,5 +1,5 @@
 {
-  "CiPipelineFiles": "[\".woodpecker/.ci.yml\"]",
+  "CiPipelineFiles": "",
   "CiPipelineNumber": "1",
   "CiPipelineParent": "0",
   "CiPipelineEvent": "push",
@@ -11,7 +11,7 @@
   "CiPipelineCreatedT": "2024-01-19-04-22-21",
   "CiPipelineStarted": 1705638156,
   "CiPipelineStartedT": "2024-01-19-04-22-36",
-  "CiPipelineFinished": 1705458166,
-  "CiPipelineFinishedT": "2024-01-17-02-22-46",
-  "CiPipelineDurationHuman": "N/A"
+  "CiPipelineFinished": 0,
+  "CiPipelineFinishedT": "",
+  "CiPipelineDurationHuman": "377d 22h 14m 30s"
 }

--- a/wd_mock_test/testdata/TestNewCurrentPipelineInfo/sample.golden
+++ b/wd_mock_test/testdata/TestNewCurrentPipelineInfo/sample.golden
@@ -1,5 +1,5 @@
 {
-  "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+  "CiPipelineFiles": "",
   "CiPipelineNumber": "10",
   "CiPipelineParent": "0",
   "CiPipelineEvent": "push",
@@ -11,7 +11,7 @@
   "CiPipelineCreatedT": "2024-01-19-09-55-41",
   "CiPipelineStarted": 1705658156,
   "CiPipelineStartedT": "2024-01-19-09-55-56",
-  "CiPipelineFinished": 1705658166,
-  "CiPipelineFinishedT": "2024-01-19-09-56-06",
-  "CiPipelineDurationHuman": "10s"
+  "CiPipelineFinished": 0,
+  "CiPipelineFinishedT": "",
+  "CiPipelineDurationHuman": "377d 16h 41m 10s"
 }

--- a/wd_mock_test/testdata/TestNewCurrentPipelineInfo/sample.golden
+++ b/wd_mock_test/testdata/TestNewCurrentPipelineInfo/sample.golden
@@ -13,5 +13,5 @@
   "CiPipelineStartedT": "2024-01-19-09-55-56",
   "CiPipelineFinished": 0,
   "CiPipelineFinishedT": "",
-  "CiPipelineDurationHuman": "377d 16h 41m 10s"
+  "CiPipelineDurationHuman": "10s"
 }

--- a/wd_mock_test/testdata/TestNewWoodpeckerInfo/failure-status.golden
+++ b/wd_mock_test/testdata/TestNewWoodpeckerInfo/failure-status.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestNewWoodpeckerInfo/sample.golden
+++ b/wd_mock_test/testdata/TestNewWoodpeckerInfo/sample.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/fastPullRequest.golden
+++ b/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/fastPullRequest.golden
@@ -45,8 +45,8 @@
     "CreatedAt": "2024-01-19-09-55-41",
     "Started": 1705658156,
     "StartedAt": "2024-01-19-09-55-56",
-    "Finished": 1705658166,
-    "FinishedAt": "2024-01-19-09-56-06",
+    "Finished": 0,
+    "FinishedAt": "",
     "DurationHuman": "25s"
   },
   "Commit": {

--- a/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/fastTag.golden
+++ b/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/fastTag.golden
@@ -45,8 +45,8 @@
     "CreatedAt": "2024-01-19-09-55-41",
     "Started": 1705658156,
     "StartedAt": "2024-01-19-09-55-56",
-    "Finished": 1705658166,
-    "FinishedAt": "2024-01-19-09-56-06",
+    "Finished": 0,
+    "FinishedAt": "",
     "DurationHuman": "25s"
   },
   "Commit": {

--- a/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/sample.golden
+++ b/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/sample.golden
@@ -45,8 +45,8 @@
     "CreatedAt": "2024-01-19-09-55-41",
     "Started": 1705658156,
     "StartedAt": "2024-01-19-09-55-56",
-    "Finished": 1705658166,
-    "FinishedAt": "2024-01-19-09-56-06",
+    "Finished": 0,
+    "FinishedAt": "",
     "DurationHuman": "25s"
   },
   "Commit": {

--- a/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/statusFailure.golden
+++ b/wd_mock_test/testdata/TestParseWoodpeckerInfo2Shot/statusFailure.golden
@@ -45,8 +45,8 @@
     "CreatedAt": "2024-01-19-09-55-41",
     "Started": 1705658156,
     "StartedAt": "2024-01-19-09-55-56",
-    "Finished": 1705658166,
-    "FinishedAt": "2024-01-19-09-56-06",
+    "Finished": 0,
+    "FinishedAt": "",
     "DurationHuman": "25s"
   },
   "Commit": {

--- a/wd_mock_test/testdata/TestWoodPeckerEnvMock/sample.golden
+++ b/wd_mock_test/testdata/TestWoodPeckerEnvMock/sample.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPullRequest.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPullRequest.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "pull_request",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPullRequestClose.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPullRequestClose.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "pull_request_closed",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPushCommitBranch.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastPushCommitBranch.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastTag.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/fastTag.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "tag",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/statusFailure.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/statusFailure.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/statusSuccess.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/statusSuccess.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/worksSpace.golden
+++ b/wd_mock_test/testdata/TestWoodpeckerInfoFastMock/worksSpace.golden
@@ -53,7 +53,7 @@
       "CiCommitPreRelease": false
     },
     "CurrentPipelineInfo": {
-      "CiPipelineFiles": "[\".woodpecker/.build.yml\"]",
+      "CiPipelineFiles": "",
       "CiPipelineNumber": "10",
       "CiPipelineParent": "0",
       "CiPipelineEvent": "push",
@@ -65,8 +65,8 @@
       "CiPipelineCreatedT": "2024-01-19-09-55-41",
       "CiPipelineStarted": 1705658156,
       "CiPipelineStartedT": "2024-01-19-09-55-56",
-      "CiPipelineFinished": 1705658166,
-      "CiPipelineFinishedT": "2024-01-19-09-56-06",
+      "CiPipelineFinished": 0,
+      "CiPipelineFinishedT": "",
       "CiPipelineDurationHuman": "25s"
     },
     "CurrentWorkflowInfo": {

--- a/wd_mock_test/wd_mock_current_pipeline_info_test.go
+++ b/wd_mock_test/wd_mock_current_pipeline_info_test.go
@@ -10,16 +10,17 @@ import (
 func TestNewCurrentPipelineInfo(t *testing.T) {
 	// mock NewCurrentPipelineInfo
 	type args struct {
-		ciPipelineNumber       string
-		ciPipelineParent       string
-		ciPipelineEvent        string
-		ciPipelineUrl          string
-		ciPipelineForgeUrl     string
-		ciPipelineDeployTarget string
-		ciPipelineStatus       string
-		ciPipelineCreated      uint64
-		ciPipelineStarted      uint64
-		ciPipelineFinished     uint64
+		ciPipelineNumber        string
+		ciPipelineParent        string
+		ciPipelineEvent         string
+		ciPipelineUrl           string
+		ciPipelineForgeUrl      string
+		ciPipelineDeployTarget  string
+		ciPipelineStatus        string
+		ciPipelineCreated       uint64
+		ciPipelineStarted       uint64
+		ciPipelineFinished      uint64
+		ciPipelineDurationHuman string
 	}
 	tests := []struct {
 		name    string
@@ -29,31 +30,33 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 		{
 			name: "sample", // testdata/TestNewCurrentPipelineInfo/sample.golden
 			args: args{
-				ciPipelineNumber:       "10",
-				ciPipelineParent:       "0",
-				ciPipelineEvent:        "push",
-				ciPipelineUrl:          "https://woodpecker.domain.com/repos/2/pipeline/10",
-				ciPipelineForgeUrl:     "https://gitea.domain.com/woodpecker-kit/guidance-woodpecker-agent/commit/9c764dd487bce596c5c0402478fabde5f0344983",
-				ciPipelineDeployTarget: "",
-				ciPipelineStatus:       "success",
-				ciPipelineCreated:      1705658141,
-				ciPipelineStarted:      1705658156,
-				ciPipelineFinished:     1705658166,
+				ciPipelineNumber:        "10",
+				ciPipelineParent:        "0",
+				ciPipelineEvent:         "push",
+				ciPipelineUrl:           "https://woodpecker.domain.com/repos/2/pipeline/10",
+				ciPipelineForgeUrl:      "https://gitea.domain.com/woodpecker-kit/guidance-woodpecker-agent/commit/9c764dd487bce596c5c0402478fabde5f0344983",
+				ciPipelineDeployTarget:  "",
+				ciPipelineStatus:        "success",
+				ciPipelineCreated:       1705658141,
+				ciPipelineStarted:       1705658156,
+				ciPipelineFinished:      1705658166,
+				ciPipelineDurationHuman: "10s",
 			},
 		},
 		{
 			name: "one", // testdata/TestNewCurrentPipelineInfo/one.golden
 			args: args{
-				ciPipelineNumber:       "1",
-				ciPipelineParent:       "0",
-				ciPipelineEvent:        "push",
-				ciPipelineUrl:          "https://woodpecker.domain.com/repos/2/pipeline/1",
-				ciPipelineForgeUrl:     "https://gitea.domain.com/woodpecker-kit/guidance-woodpecker-agent/commit/9c764dd487bce596c5c0402478fabde5f0345983",
-				ciPipelineDeployTarget: "",
-				ciPipelineStatus:       "success",
-				ciPipelineCreated:      1705638141,
-				ciPipelineStarted:      1705638156,
-				ciPipelineFinished:     1705458166,
+				ciPipelineNumber:        "1",
+				ciPipelineParent:        "0",
+				ciPipelineEvent:         "push",
+				ciPipelineUrl:           "https://woodpecker.domain.com/repos/2/pipeline/1",
+				ciPipelineForgeUrl:      "https://gitea.domain.com/woodpecker-kit/guidance-woodpecker-agent/commit/9c764dd487bce596c5c0402478fabde5f0345983",
+				ciPipelineDeployTarget:  "",
+				ciPipelineStatus:        "success",
+				ciPipelineCreated:       1705638141,
+				ciPipelineStarted:       1705638156,
+				ciPipelineFinished:      1705458166,
+				ciPipelineDurationHuman: "5s",
 			},
 		},
 	}
@@ -75,6 +78,11 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 				wd_mock.WithCiPipelineCreated(tc.args.ciPipelineCreated),
 				wd_mock.WithCiPipelineStarted(tc.args.ciPipelineStarted),
 			)
+			// for mock ciPipelineDurationHuman by args
+			if tc.args.ciPipelineDurationHuman != "" {
+				gotResult.CiPipelineDurationHuman = tc.args.ciPipelineDurationHuman
+			}
+
 			assert.Equal(t, tc.wantErr, gotResult == nil)
 			if tc.wantErr {
 				return

--- a/wd_mock_test/wd_mock_current_pipeline_info_test.go
+++ b/wd_mock_test/wd_mock_current_pipeline_info_test.go
@@ -10,7 +10,6 @@ import (
 func TestNewCurrentPipelineInfo(t *testing.T) {
 	// mock NewCurrentPipelineInfo
 	type args struct {
-		ciPipelineFiles        string
 		ciPipelineNumber       string
 		ciPipelineParent       string
 		ciPipelineEvent        string
@@ -30,7 +29,6 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 		{
 			name: "sample", // testdata/TestNewCurrentPipelineInfo/sample.golden
 			args: args{
-				ciPipelineFiles:        `[".woodpecker/.build.yml"]`,
 				ciPipelineNumber:       "10",
 				ciPipelineParent:       "0",
 				ciPipelineEvent:        "push",
@@ -46,7 +44,6 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 		{
 			name: "one", // testdata/TestNewCurrentPipelineInfo/one.golden
 			args: args{
-				ciPipelineFiles:        `[".woodpecker/.ci.yml"]`,
 				ciPipelineNumber:       "1",
 				ciPipelineParent:       "0",
 				ciPipelineEvent:        "push",
@@ -68,7 +65,6 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 
 			// do NewCurrentPipelineInfo
 			gotResult := wd_mock.NewCurrentPipelineInfo(
-				wd_mock.WithCiPipelineFiles(tc.args.ciPipelineFiles),
 				wd_mock.WithCiPipelineNumber(tc.args.ciPipelineNumber),
 				wd_mock.WithCiPipelineParent(tc.args.ciPipelineParent),
 				wd_mock.WithCiPipelineEvent(tc.args.ciPipelineEvent),
@@ -78,7 +74,6 @@ func TestNewCurrentPipelineInfo(t *testing.T) {
 				wd_mock.WithCiPipelineStatus(tc.args.ciPipelineStatus),
 				wd_mock.WithCiPipelineCreated(tc.args.ciPipelineCreated),
 				wd_mock.WithCiPipelineStarted(tc.args.ciPipelineStarted),
-				wd_mock.WithCiPipelineFinished(tc.args.ciPipelineFinished),
 			)
 			assert.Equal(t, tc.wantErr, gotResult == nil)
 			if tc.wantErr {

--- a/wd_short_info/short_parse.go
+++ b/wd_short_info/short_parse.go
@@ -55,8 +55,6 @@ func ParseWoodpeckerInfo2Short(info wd_info.WoodpeckerInfo) WoodpeckerInfoShort 
 			CreatedAt:     info.CurrentInfo.CurrentPipelineInfo.CiPipelineCreatedT,
 			Started:       info.CurrentInfo.CurrentPipelineInfo.CiPipelineStarted,
 			StartedAt:     info.CurrentInfo.CurrentPipelineInfo.CiPipelineStartedT,
-			Finished:      info.CurrentInfo.CurrentPipelineInfo.CiPipelineFinished,
-			FinishedAt:    info.CurrentInfo.CurrentPipelineInfo.CiPipelineFinishedT,
 			DurationHuman: info.CurrentInfo.CurrentPipelineInfo.CiPipelineDurationHuman,
 		},
 		Commit: Commit{
@@ -123,7 +121,10 @@ func ParseWoodpeckerInfo2Short(info wd_info.WoodpeckerInfo) WoodpeckerInfoShort 
 
 func relatedShortInfo(w *WoodpeckerInfoShort) {
 	if w.Build.Status == "" {
+		// https://github.com/woodpecker-ci/woodpecker/pull/4193
 		relateCIPipelineStatus := env_kit.FetchOsEnvStr(wd_flag.RelatedEnvDroneCIPipelineStatus, "")
-		w.Build.Status = relateCIPipelineStatus
+		if relateCIPipelineStatus != "" {
+			w.Build.Status = relateCIPipelineStatus
+		}
 	}
 }

--- a/wd_short_info/wd_info_short.go
+++ b/wd_short_info/wd_info_short.go
@@ -160,10 +160,10 @@ type (
 		// StartedAt
 		// from wd_info.CurrentPipelineInfo CiPipelineStartedT
 		StartedAt string
-		// Finished
+		// Deprecated: remove at woodpecker server 3.0.0
 		// from wd_info.CurrentPipelineInfo CiPipelineFinished
 		Finished uint64
-		// FinishedAt
+		// Deprecated: remove at woodpecker server 3.0.0
 		// from wd_info.CurrentPipelineInfo CiPipelineFinishedT
 		FinishedAt string
 		// DurationHuman

--- a/wd_urfave_cli_v2/bind_cli.go
+++ b/wd_urfave_cli_v2/bind_cli.go
@@ -18,9 +18,7 @@ func UrfaveCliBindInfo(c *cli.Context) wd_info.WoodpeckerInfo {
 	pipelineCreateAtT := wd_flag.FormatTimeUTCBySetting(pipelineCreateAt)
 	pipelineStartAt := c.Uint64(wd_flag.NameCliCurrentPipelineStarted)
 	pipelineStartAtT := wd_flag.FormatTimeUTCBySetting(pipelineStartAt)
-	pipelineFinishAt := c.Uint64(wd_flag.NameCliCurrentPipelineFinished)
-	pipelineFinishAtT := wd_flag.FormatTimeUTCBySetting(pipelineFinishAt)
-	pipelineDurationHuman := wd_flag.DistanceBetweenTimestampSecondHuman(int64(pipelineCreateAt), int64(pipelineFinishAt))
+	pipelineDurationHuman := wd_flag.DistanceBetweenTimestampSecondHuman(int64(pipelineCreateAt), wd_flag.GetNowTimestampSecond())
 
 	previousPipelineCreateAt := c.Uint64(wd_flag.NameCliPreviousPipelineCreated)
 	previousPipelineCreateAtT := wd_flag.FormatTimeUTCBySetting(previousPipelineCreateAt)
@@ -56,7 +54,6 @@ func UrfaveCliBindInfo(c *cli.Context) wd_info.WoodpeckerInfo {
 		},
 
 		CurrentPipelineInfo: wd_info.CurrentPipelineInfo{
-			CiPipelineFiles:         c.String(wd_flag.NameCliCurrentPipelineFiles),
 			CiPipelineNumber:        c.String(wd_flag.NameCliCurrentPipelineNumber),
 			CiPipelineParent:        c.String(wd_flag.NameCliCurrentPipelineParent),
 			CiPipelineEvent:         c.String(wd_flag.NameCliCurrentPipelineEvent),
@@ -68,8 +65,6 @@ func UrfaveCliBindInfo(c *cli.Context) wd_info.WoodpeckerInfo {
 			CiPipelineCreatedT:      pipelineCreateAtT,
 			CiPipelineStarted:       pipelineStartAt,
 			CiPipelineStartedT:      pipelineStartAtT,
-			CiPipelineFinished:      pipelineFinishAt,
-			CiPipelineFinishedT:     pipelineFinishAtT,
 			CiPipelineDurationHuman: pipelineDurationHuman,
 		},
 

--- a/wd_urfave_cli_v2/u_flag_current_pipeline.go
+++ b/wd_urfave_cli_v2/u_flag_current_pipeline.go
@@ -8,13 +8,6 @@ import (
 func currentPipelineFlag() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:    wd_flag.NameCliCurrentPipelineFiles,
-			Usage:   "Provides the current pipeline files just like [\".woodpecker/.build.yml\"]",
-			EnvVars: []string{wd_flag.EnvKeyCurrentPipelineFiles},
-			Hidden:  true,
-		},
-
-		&cli.StringFlag{
 			Name:    wd_flag.NameCliCurrentPipelineNumber,
 			Usage:   "Provides the current pipeline number",
 			EnvVars: []string{wd_flag.EnvKeyCurrentPipelineNumber},
@@ -74,13 +67,6 @@ func currentPipelineFlag() []cli.Flag {
 			Name:    wd_flag.NameCliCurrentPipelineStarted,
 			Usage:   "Provides the current pipeline started timestamp",
 			EnvVars: []string{wd_flag.EnvKeyCurrentPipelineStarted},
-			Hidden:  true,
-		},
-
-		&cli.Uint64Flag{
-			Name:    wd_flag.NameCliCurrentPipelineFinished,
-			Usage:   "Provides the current pipeline finished timestamp",
-			EnvVars: []string{wd_flag.EnvKeyCurrentPipelineFinished},
 			Hidden:  true,
 		},
 	}


### PR DESCRIPTION
Deprecated `CI_PIPELINE_FINISHED` and `CI_PIPELINE_FILES`

feat #66

- Remove current pipeline finished related flags and code
- Add deprecated comments for removal in woodpecker 3.0.0
- Update time tools with new functions for current timestamp
- Adjust pipeline duration calculation to use current time instead of finished time